### PR TITLE
Fix countable php 8.1 deprecation

### DIFF
--- a/src/FilterAggregateIterator.php
+++ b/src/FilterAggregateIterator.php
@@ -36,6 +36,7 @@ class FilterAggregateIterator extends AbstractIterator implements \Countable, Fi
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);


### PR DESCRIPTION
### Description
Fix countable php 8.1 deprecation

```text
Fatal error: During inheritance of Countable: Uncaught ErrorException: Return type of ShoppingFeed\Iterator\FilterAggregateIterator::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/vendor/shoppingfeed/iterator/src/FilterAggregateIterator.php:39
```